### PR TITLE
feat: Add a new API function to retrieve the last commit info (resolves #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ in the script for the detail of parameters.
 * createBranch(octokit, options)
 * deleteBranch(octokit, options)
 * fetchRemoteFile(octokit, options)
+* getFileLastCommit(octokit, options)
 * createSingleFile(octokit, options)
 * updateSingleFile(octokit, options)
 * commitMultipleFiles(octokit, options)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
-# data-update-github
+# git-ops-api
 
-A remote data change triggers the issue of a pull request to a specified Github repository.
+This repository supports GitHub operation API for manipulating branches and files in remote GitHub repositories.
+This API makes use of [GitHub REST API](https://docs.github.com/en/rest) and [GitHub GraphQL API](https://docs.github.com/en/graphql).
+
+## Git Operation API
+
+* Script: lib/gitOpsApi.js
+
+Includes API for operating remote Github branches and files. All API functions return a promise. Refer to the JSDoc
+in the script for the detail of parameters.
+
+* getBranchRef(octokit, options)
+* getAllBranches(octokit, options)
+* createBranch(octokit, options)
+* deleteBranch(octokit, options)
+* fetchRemoteFile(octokit, options)
+* createSingleFile(octokit, options)
+* updateSingleFile(octokit, options)
+* commitMultipleFiles(octokit, options)
+* issuePullRequest(octokit, options)
 
 ## Install
 
@@ -18,7 +36,7 @@ Run `npm run test` to run tests.
 
 Note that tests for Git operation API (`tests/gitOpsApiTests.js`) is not included in `npm run test` command. This test
 requires a personal access token that has the privilege to operate
-[inclusive-design/data-update-github](https://github.com/inclusive-design/data-update-github/).
+[inclusive-design/git-ops-api](https://github.com/inclusive-design/git-ops-api/).
 This access token can be supplied by defining an environment variable named "ACCESS_TOKEN" or passed as an argument
 when running the script `node tests/gitOpsApiTests.js {access_token}`.
 
@@ -30,11 +48,11 @@ Create a `.env` at the root directory with a content:
 ACCESS_TOKEN={String}
 ```
 
-## Scripts
+## Demos
 
 ### Auto update ODC data files
 
-* Script: scripts/fetchODCDataFiles.js
+* Script: demos/fetchODCDataFiles.js
 
 * Goal: Check if a new version of the open dataset documenting COVID-19 assessment centre locations has been published
 on the [Ontario Data Catalogue API](https://data.ontario.ca/api/3/action/package_show?id=covid-19-assessment-centre-locations).
@@ -45,25 +63,8 @@ them into [COVID assessment centres data repository](https://github.com/inclusiv
   * Define an environment variable `ACCESS_TOKEN`: The personal access token of a Github account that commits will be
    issued on behalf. Refer to [the Github documentation](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token)
 about how to create a Github personal access token.
-  * Visit [the config file](./scripts/fetchODCConfig.json5) to set proper config values. Purpose of these values are
+  * Visit [the config file](./demos/fetchODCConfig.json5) to set proper config values. Purpose of these values are
 explained in the config file.
 
 * How to run:
-`node scripts/fetchODCDataFiles.js`
-
-## Git Operation API
-
-* Script: scripts/gitOpsApi.js
-
-Includes API for operating remote Github branches and files. All API functions return a promise. Refer to the JSDoc
-in the script for the detail of parameters.
-
-* getBranchRef(octokit, options)
-* getAllBranches(octokit, options)
-* createBranch(octokit, options)
-* deleteBranch(octokit, options)
-* fetchRemoteFile(octokit, options)
-* createSingleFile(octokit, options)
-* updateSingleFile(octokit, options)
-* commitMultipleFiles(octokit, options)
-* issuePullRequest(octokit, options)
+`node demos/fetchODCDataFiles.js`

--- a/demos/fetchODCConfig.json5
+++ b/demos/fetchODCConfig.json5
@@ -1,4 +1,4 @@
-// Contains all configs used by scripts/fetchODCDataFiles.js for committing newly published ODC data files of
+// Contains all configs used by demos/fetchODCDataFiles.js for committing newly published ODC data files of
 // COVID-19 assessment centre locations into WeCount Github repository.
 {
 	// Github REST API

--- a/demos/fetchODCDataFiles.js
+++ b/demos/fetchODCDataFiles.js
@@ -3,7 +3,7 @@ Copyright 2020 OCAD University
 
 Licensed under the New BSD license. You may not use this file except in compliance with this licence.
 You may obtain a copy of the BSD License at
-https://raw.githubusercontent.com/inclusive-design/data-update-github/main/LICENSE
+https://raw.githubusercontent.com/inclusive-design/git-ops-api/main/LICENSE
 */
 
 // This script checks if a new data file is published on the data source URL. If there is,
@@ -15,13 +15,13 @@ https://raw.githubusercontent.com/inclusive-design/data-update-github/main/LICEN
 // ACCESS_TOKEN: The personal access token of a Github account that commits will be issued on behalf.
 //
 // A sample command that runs this script in the universal root directory:
-// node scripts/fetchODCDataFiles.js
+// node demos/fetchODCDataFiles.js
 
 "use strict";
 
 require("dotenv").config();
 
-const gitOpsApi = require("./gitOpsApi.js");
+const gitOpsApi = require("../lib/gitOpsApi.js");
 const utils = require("./fetchODCDataFilesUtils.js");
 require("json5/lib/register");
 

--- a/demos/fetchODCDataFilesUtils.js
+++ b/demos/fetchODCDataFilesUtils.js
@@ -3,7 +3,7 @@ Copyright 2021 OCAD University
 
 Licensed under the New BSD license. You may not use this file except in compliance with this licence.
 You may obtain a copy of the BSD License at
-https://raw.githubusercontent.com/inclusive-design/data-update-github/main/LICENSE
+https://raw.githubusercontent.com/inclusive-design/git-ops-api/main/LICENSE
 */
 
 // Utility functions used by fetchODCDataFiles.js

--- a/lib/gitOpsApi.js
+++ b/lib/gitOpsApi.js
@@ -127,7 +127,8 @@ module.exports = {
 	 * @typedef {Object} FileOptions
 	 * @param {String} repoOwner - The repo owner.
 	 * @param {String} repoName - The repo name.
-	 * @param {String} branchName - The name of the remote branch to operate.
+	 * @param {String} branchName - (optional) The name of the remote branch to operate. if it is omitted,
+	 * the fetch will use the repository's default branch.
 	 * @param {String} filePath - The location of the file including the path and the file name.
 	 */
 
@@ -378,8 +379,6 @@ module.exports = {
 				ref: "heads/" + branchName,
 				sha: commit.data.sha
 			});
-			console.log("done");
-
 			return "Committed successfully.";
 		} catch(e) {
 			throw {

--- a/lib/gitOpsApi.js
+++ b/lib/gitOpsApi.js
@@ -3,7 +3,7 @@ Copyright 2021 OCAD University
 
 Licensed under the New BSD license. You may not use this file except in compliance with this licence.
 You may obtain a copy of the BSD License at
-https://raw.githubusercontent.com/inclusive-design/data-update-github/main/LICENSE
+https://raw.githubusercontent.com/inclusive-design/git-ops-api/main/LICENSE
 */
 
 // API for Github operations.
@@ -31,22 +31,21 @@ module.exports = {
 	 * {isError: true, message: [error-message]};
 	 */
 	getAllBranches: async (octokit, options) => {
-		return new Promise((resolve, reject) => {
-			return octokit.request("GET /repos/{owner}/{repo}/branches", {
+		try {
+			const response = await octokit.request("GET /repos/{owner}/{repo}/branches", {
 				headers: {
 					"Cache-Control": "no-store, max-age=0"
 				},
 				owner: options.repoOwner,
 				repo: options.repoName
-			}).then((response) => {
-				resolve(response.data);
-			}).catch((e) => {
-				reject({
-					isError: true,
-					message: "Error at getAllBranches(): " + e.message
-				});
 			});
-		});
+			return response.data;
+		} catch(e) {
+			throw {
+				isError: true,
+				message: "Error at getAllBranches(): " + e.message
+			};
+		}
 	},
 
 	/**
@@ -69,32 +68,25 @@ module.exports = {
 	 * {isError: true, message: [error-message]};
 	 */
 	createBranch: async (octokit, options) => {
-		return new Promise((resolve, reject) => {
-			return getBranchRef(octokit, {
+		try {
+			const commit = await getBranchRef(octokit, {
 				repoOwner: options.repoOwner,
 				repoName: options.repoName,
 				branchName: options.baseBranchName
-			}).then((commit) => {
-				return octokit.request("POST /repos/{owner}/{repo}/git/refs", {
-					owner: options.repoOwner,
-					repo: options.repoName,
-					ref: "refs/heads/" + options.targetBranchName,
-					sha: commit.object.sha
-				}).then((res) => {
-					resolve(res.data);
-				}).catch((e) => {
-					reject({
-						isError: true,
-						message: "Error at createBranch(): " + e.message
-					});
-				});
-			}).catch((e) => {
-				reject({
-					isError: true,
-					message: "Error at createBranch(): " + e.message
-				});
 			});
-		});
+			const response = await octokit.request("POST /repos/{owner}/{repo}/git/refs", {
+				owner: options.repoOwner,
+				repo: options.repoName,
+				ref: "refs/heads/" + options.targetBranchName,
+				sha: commit.object.sha
+			});
+			return response.data;
+		} catch(e) {
+			throw {
+				isError: true,
+				message: "Error at createBranch(): " + e.message
+			};
+		}
 	},
 
 	/**
@@ -115,20 +107,19 @@ module.exports = {
 	 * {isError: true, message: [error-message]};
 	 */
 	deleteBranch: async (octokit, options) => {
-		return new Promise((resolve, reject) => {
-			return octokit.request("DELETE /repos/{owner}/{repo}/git/refs/{ref}", {
+		try {
+			const response = await octokit.request("DELETE /repos/{owner}/{repo}/git/refs/{ref}", {
 				owner: options.repoOwner,
 				repo: options.repoName,
 				ref: "heads/" + options.branchName
-			}).then(() => {
-				resolve(options.branchName + " has been deleted successfully.");
-			}).catch((e) => {
-				reject({
-					isError: true,
-					message: "Error at deleteBranch(): " + e.message
-				});
 			});
-		});
+			return options.branchName + " has been deleted successfully.";
+		} catch(e) {
+			throw {
+				isError: true,
+				message: "Error at deleteBranch(): " + e.message
+			};
+		}
 	},
 
 	/**
@@ -152,8 +143,8 @@ module.exports = {
 	 * {isError: true, message: [error-message]};
 	 */
 	fetchRemoteFile: async (octokit, options) => {
-		return new Promise((resolve, reject) => {
-			octokit.request("GET /repos/{owner}/{repo}/contents/{path}", {
+		try {
+			const response = await octokit.request("GET /repos/{owner}/{repo}/contents/{path}", {
 				headers: {
 					"Cache-Control": "no-store, max-age=0"
 				},
@@ -161,25 +152,24 @@ module.exports = {
 				repo: options.repoName,
 				path: options.filePath,
 				ref: options.branchName
-			}).then((response) => {
-				resolve({
-					exists: true,
-					content: Buffer.from(response.data.content, "base64").toString("utf-8"),
-					sha: response.data.sha
-				});
-			}, (e) => {
-				if (e.message === "Not Found") {
-					resolve({
-						exists: false
-					});
-				} else {
-					reject({
-						isError: true,
-						message: "Error at fetchRemoteFile(): " + e.message
-					});
-				}
 			});
-		});
+			return {
+				exists: true,
+				content: Buffer.from(response.data.content, "base64").toString("utf-8"),
+				sha: response.data.sha
+			};
+		} catch(e) {
+			if (e.message === "Not Found") {
+				return {
+					exists: false
+				};
+			} else {
+				throw {
+					isError: true,
+					message: "Error at fetchRemoteFile(): " + e.message
+				};
+			}
+		}
 	},
 
 	/**
@@ -200,8 +190,8 @@ module.exports = {
 	 * {isError: true, message: [error-message]};
 	 */
 	getFileLastCommit: async (octokit, options) => {
-		return new Promise((resolve, reject) => {
-			octokit.request("GET /repos/{owner}/{repo}/commits", {
+		try {
+			const response = await octokit.request("GET /repos/{owner}/{repo}/commits", {
 				headers: {
 					"Cache-Control": "no-store, max-age=0"
 				},
@@ -211,15 +201,14 @@ module.exports = {
 				sha: options.branchName,
 				page: 1,
 				per_page: 1
-			}).then((response) => {
-				resolve(response.data[0].commit);
-			}, (e) => {
-				reject({
-					isError: true,
-					message: "Error at getFileLastCommit(): " + e.message
-				});
 			});
-		});
+			return response.data[0].commit;
+		} catch(e) {
+			throw {
+				isError: true,
+				message: "Error at getFileLastCommit(): " + e.message
+			};
+		}
 	},
 
 	/**
@@ -242,23 +231,22 @@ module.exports = {
 	 * with an object in a structure of: {isError: true, message: {error-message}}
 	 */
 	createSingleFile: async (octokit, options) => {
-	    return new Promise((resolve, reject) => {
-	        octokit.request("PUT /repos/{owner}/{repo}/contents/{path}", {
+		try {
+			await octokit.request("PUT /repos/{owner}/{repo}/contents/{path}", {
 	            owner: options.repoOwner,
 	            repo: options.repoName,
 	            path: options.filePath,
 	            message: options.commitMessage,
 	            content: Buffer.from(options.fileContent).toString("base64"),
 	            branch: options.branchName
-	        }).then(() => {
-	            resolve(options.filePath + " has been created successfully.");
-	        }).catch((e) => {
-	            reject({
-					isError: true,
-					message: "Error at createSingleFile(): " + e.message
-				});
 	        });
-	    });
+			return options.filePath + " has been created successfully.";
+		} catch(e) {
+			throw {
+				isError: true,
+				message: "Error at createSingleFile(): " + e.message
+			};
+		}
 	},
 
 	/**
@@ -282,8 +270,8 @@ module.exports = {
 	 * with an object in a structure of: {isError: true, message: {error-message}}
 	 */
 	updateSingleFile: async (octokit, options) => {
-	    return new Promise((resolve, reject) => {
-	        octokit.request("PUT /repos/{owner}/{repo}/contents/{path}", {
+		try {
+			await octokit.request("PUT /repos/{owner}/{repo}/contents/{path}", {
 	            owner: options.repoOwner,
 	            repo: options.repoName,
 	            path: options.filePath,
@@ -291,15 +279,14 @@ module.exports = {
 	            content: Buffer.from(options.fileContent).toString("base64"),
 	            branch: options.branchName,
 				sha: options.sha
-	        }).then(() => {
-	            resolve(options.filePath + " has been updated successfully.");
-	        }).catch((e) => {
-	            reject({
-					isError: true,
-					message: "Error at updateSingleFile(): " + e.message
-				});
 	        });
-	    });
+			return options.filePath + " has been updated successfully.";
+		} catch(e) {
+			throw {
+				isError: true,
+				message: "Error at updateSingleFile(): " + e.message
+			};
+		}
 	},
 
 	/**
@@ -337,74 +324,69 @@ module.exports = {
 		 * @return {Promise} The resolve or reject of the promise indicates whether the operation completes successfully.
 		 */
 		const getTree = async function (repoOwner, repoName, branchName) {
-			return module.exports.getBranchRef(octokit, {
+			parentCommit = await module.exports.getBranchRef(octokit, {
 				repoOwner: repoOwner,
 				repoName: repoName,
 				branchName: branchName
-			}).then((commit) => {
-				parentCommit = commit;
-				return octokit.request("GET /repos/{owner}/{repo}/git/trees/{tree_sha}", {
-					owner: repoOwner,
-					repo: repoName,
-					tree_sha: commit.object.sha
-				});
 			});
+			const tree = await octokit.request("GET /repos/{owner}/{repo}/git/trees/{tree_sha}", {
+				owner: repoOwner,
+				repo: repoName,
+				tree_sha: parentCommit.object.sha
+			});
+			return tree;
 		};
 
 		// This sequence for submitting multiple files in one commit is referenced from
 		// https://gist.github.com/StephanHoyer/91d8175507fcae8fb31a
-		return new Promise((resolve, reject) => {
-			return Promise.all(files.map((file) => {
+		try {
+			const blobs = await Promise.all(files.map((file) => {
 				return octokit.request("POST /repos/{owner}/{repo}/git/blobs", {
 					owner: repoOwner,
 					repo: repoName,
 					content: file.content
 				});
-			})).then((blobs) => {
-				return getTree(repoOwner, repoName, branchName).then(function (tree) {
-					return octokit.request("POST /repos/{owner}/{repo}/git/trees", {
-						owner: repoOwner,
-						repo: repoName,
-						tree: files.map(function (file, index) {
-							return {
-								path: file.path,
-								mode: "100644",
-								type: "blob",
-								sha: blobs[index].data.sha
-							};
-						}),
-						base_tree: tree.data.sha
-					});
-				});
-			}).then((tree) => {
-				return octokit.request("POST /repos/{owner}/{repo}/git/commits", {
-					owner: repoOwner,
-					repo: repoName,
-					message: commitMessage,
-					tree: tree.data.sha,
-					parents: [parentCommit.object.sha]
-				});
-			}).then((commit) => {
-				return octokit.request("PATCH /repos/{owner}/{repo}/git/refs/{ref}", {
-					owner: repoOwner,
-					repo: repoName,
-					ref: "heads/" + branchName,
-					sha: commit.data.sha
-				}).then(() => {
-					resolve("Committed successfully.");
-				}).catch((e) => {
-					reject({
-						isError: true,
-						message: "Error at commitMultipleFiles(): " + e.message
-					});
-				});
-			}).catch((e) => {
-				reject({
-					isError: true,
-					message: "Error at commitMultipleFiles(): " + e.message
-				});
+			}));
+
+			const tree = await getTree(repoOwner, repoName, branchName);
+
+			const newTree = await octokit.request("POST /repos/{owner}/{repo}/git/trees", {
+				owner: repoOwner,
+				repo: repoName,
+				tree: files.map(function (file, index) {
+					return {
+						path: file.path,
+						mode: "100644",
+						type: "blob",
+						sha: blobs[index].data.sha
+					};
+				}),
+				base_tree: tree.data.sha
 			});
-		});
+
+			const commit = await octokit.request("POST /repos/{owner}/{repo}/git/commits", {
+				owner: repoOwner,
+				repo: repoName,
+				message: commitMessage,
+				tree: newTree.data.sha,
+				parents: [parentCommit.object.sha]
+			});
+
+			await octokit.request("PATCH /repos/{owner}/{repo}/git/refs/{ref}", {
+				owner: repoOwner,
+				repo: repoName,
+				ref: "heads/" + branchName,
+				sha: commit.data.sha
+			});
+			console.log("done");
+
+			return "Committed successfully.";
+		} catch(e) {
+			throw {
+				isError: true,
+				message: "Error at commitMultipleFiles(): " + e.message
+			};
+		}
 	},
 
 	/**
@@ -426,45 +408,38 @@ module.exports = {
 	 * rejects with {isError: true, message: {String}}
 	 */
 	issuePullRequest: async (octokit, options) => {
-		return new Promise((resolve, reject) => {
-			octokit.graphql(
+		try {
+			const repoInfoResponse = await octokit.graphql(
 				`query {
 					repository(owner: "${options.repoOwner}", name: "${options.repoName}") {
 						url
 						id
 					}
 				}`
-			).then((repoInfoResponse) => {
-				const repoId = repoInfoResponse.repository.id;
-				octokit.graphql(
-					`mutation {
-						createPullRequest (
-							input: {
-								baseRefName: "main",
-								headRefName: "${options.issuerGithubId}:${options.branchName}",
-								repositoryId: "${repoId}",
-								title: "${options.pullRequestTitle}"
-							}) {
-							pullRequest {
-							  url
-							}
-						  }
-					}`
-				).then((createPRResponse) => {
-					resolve(createPRResponse.createPullRequest.pullRequest.url);
-				}).catch((e) => {
-					reject({
-						isError: true,
-						message: "Error at issuePullRequest(): " + e.message
-					});
-				});
-			}).catch((e) => {
-				reject({
-					isError: true,
-					message: "Error at issuePullRequest(): " + e.message
-				});
-			});
-		});
+			);
+			const repoId = repoInfoResponse.repository.id;
+			const createPRResponse = await octokit.graphql(
+				`mutation {
+					createPullRequest (
+						input: {
+							baseRefName: "main",
+							headRefName: "${options.issuerGithubId}:${options.branchName}",
+							repositoryId: "${repoId}",
+							title: "${options.pullRequestTitle}"
+						}) {
+						pullRequest {
+						  url
+						}
+					  }
+				}`
+			);
+			return createPRResponse.createPullRequest.pullRequest.url;
+		} catch(e) {
+			throw {
+				isError: true,
+				message: "Error at issuePullRequest(): " + e.message
+			};
+		}
 	}
 };
 
@@ -487,21 +462,21 @@ module.exports = {
  * {isError: true, message: [error-message]};
  */
 async function getBranchRef(octokit, options) {
-	return new Promise((resolve, reject) => {
-		return octokit.request("GET /repos/{owner}/{repo}/git/ref/{ref}", {
+	try {
+		const response = await octokit.request("GET /repos/{owner}/{repo}/git/ref/{ref}", {
 			headers: {
 				"Cache-Control": "no-store, max-age=0"
 			},
 			owner: options.repoOwner,
 			repo: options.repoName,
 			ref: "heads/" + options.branchName
-		}).then((res) => {
-			resolve(res.data);
-		}).catch((e) => {
-			reject({
-				isError: true,
-				message: "Error at getBranchRef(): " + e.message
-			});
 		});
-	});
+
+		return response.data;
+	} catch(e) {
+		throw {
+			isError: true,
+			message: "Error at getBranchRef(): " + e.message
+		};
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "data-update-github",
+	"name": "git-ops-api",
 	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
@@ -317,9 +317,9 @@
 			"dev": true
 		},
 		"@nodelib/fs.walk": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
-			"integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.5",
@@ -445,24 +445,24 @@
 			}
 		},
 		"@types/mdast": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
-			"integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.4.tgz",
+			"integrity": "sha512-gIdhbLDFlspL53xzol2hVzrXAbzt71erJHoOwQZWssjaiouOotf03lNtMmFm9VfFkvnLWccSVjUAZGQ5Kqw+jA==",
 			"dev": true,
 			"requires": {
 				"@types/unist": "*"
 			}
 		},
 		"@types/minimist": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
-			"integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
 			"dev": true
 		},
 		"@types/parse-json": {
@@ -490,9 +490,9 @@
 			"dev": true
 		},
 		"acorn-jsx": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true
 		},
 		"ajv": {
@@ -657,9 +657,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001242",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
-			"integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
+			"version": "1.0.30001243",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001243.tgz",
+			"integrity": "sha512-vNxw9mkTBtkmLFnJRv/2rhs1yufpDfCkBZexG3Y0xdOH2Z/eE/85E4Dl5j1YUN34nZVsSp6vVRFQRrez9wJMRA==",
 			"dev": true
 		},
 		"chalk": {
@@ -978,9 +978,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.766",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.766.tgz",
-			"integrity": "sha512-u2quJ862q9reRKh/je3GXis3w38+RoXH1J9N3XjtsS6NzmUAosNsyZgUVFZPN/ZlJ3v6T0rTyZR3q/J5c6Sy5w==",
+			"version": "1.3.771",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.771.tgz",
+			"integrity": "sha512-zHMomTqkpnAD9W5rhXE1aiU3ogGFrqWzdvM4C6222SREiqsWQb2w0S7P2Ii44qCaGimmAP1z+OydllM438uJyA==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -1231,9 +1231,9 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
-			"integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+			"integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -1318,9 +1318,9 @@
 			}
 		},
 		"flatted": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
-			"integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
+			"integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
 			"dev": true
 		},
 		"fluid-glob": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "git-ops-api",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -978,9 +978,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.771",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.771.tgz",
-			"integrity": "sha512-zHMomTqkpnAD9W5rhXE1aiU3ogGFrqWzdvM4C6222SREiqsWQb2w0S7P2Ii44qCaGimmAP1z+OydllM438uJyA==",
+			"version": "1.3.772",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.772.tgz",
+			"integrity": "sha512-X/6VRCXWALzdX+RjCtBU6cyg8WZgoxm9YA02COmDOiNJEZ59WkQggDbWZ4t/giHi/3GS+cvdrP6gbLISANAGYA==",
 			"dev": true
 		},
 		"emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "data-update-github",
+	"name": "git-ops-api",
 	"version": "0.1.0",
 	"description": "A remote data change triggers the issue of a pull request to a specified Github repo.",
-	"main": "./scripts/gitOpsApi.js",
+	"main": "./lib/gitOpsApi.js",
 	"scripts": {
 		"lint": "fluid-lint-all",
 		"test": "node tests/all-tests.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "git-ops-api",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"description": "A remote data change triggers the issue of a pull request to a specified Github repo.",
 	"main": "./lib/gitOpsApi.js",
 	"scripts": {

--- a/tests/all-tests.js
+++ b/tests/all-tests.js
@@ -3,7 +3,7 @@ Copyright 2020 OCAD University
 
 Licensed under the New BSD license. You may not use this file except in compliance with this licence.
 You may obtain a copy of the BSD License at
-https://raw.githubusercontent.com/inclusive-design/data-update-github/main/LICENSE
+https://raw.githubusercontent.com/inclusive-design/git-ops-api/main/LICENSE
 */
 
 "use strict";

--- a/tests/fetchODCDataFilesUtilsTests.js
+++ b/tests/fetchODCDataFilesUtilsTests.js
@@ -3,7 +3,7 @@ Copyright 2020 OCAD University
 
 Licensed under the New BSD license. You may not use this file except in compliance with this licence.
 You may obtain a copy of the BSD License at
-https://raw.githubusercontent.com/inclusive-design/data-update-github/main/LICENSE
+https://raw.githubusercontent.com/inclusive-design/git-ops-api/main/LICENSE
 */
 
 "use strict";
@@ -13,7 +13,7 @@ const jqUnit = fluid.require("node-jqunit", require, "jqUnit");
 const fs = require("fs");
 const nock = require("nock");
 
-const utils = require("../scripts/fetchODCDataFilesUtils.js");
+const utils = require("../demos/fetchODCDataFilesUtils.js");
 
 jqUnit.module("Fetch ODC data files tests");
 

--- a/tests/gitOpsApiTests.js
+++ b/tests/gitOpsApiTests.js
@@ -40,7 +40,7 @@ const repoNameWrong = "nonexistent-repo";
 
 //****************** Success cases ******************
 
-jqUnit.asyncTest("Success cases for all API functions - ", async function () {
+jqUnit.test("Success cases for all API functions - ", async function () {
 	jqUnit.expect(9);
 	let response;
 
@@ -126,27 +126,26 @@ jqUnit.asyncTest("Success cases for all API functions - ", async function () {
 		});
 		jqUnit.assertTrue("The pull request url is returned", response.startsWith("https://github.com/"));
 
-		response = await gitOpsApi.deleteBranch(octokit, {
+		return gitOpsApi.deleteBranch(octokit, {
 			repoOwner: repoOwner,
 			repoName: repoName,
 			branchName: branchName
+		}).then(function (response) {
+			jqUnit.assertTrue("deleteBranch() completes successfully.", response.includes("has been deleted successfully"));
 		});
-		jqUnit.assertTrue("deleteBranch() completes successfully.", response.includes("has been deleted successfully"));
 	} catch (error) {
-		try {
-			response = await gitOpsApi.deleteBranch(octokit, {
-				repoOwner: repoOwner,
-				repoName: repoName,
-				branchName: branchName
-			});
+		return gitOpsApi.deleteBranch(octokit, {
+			repoOwner: repoOwner,
+			repoName: repoName,
+			branchName: branchName
+		}).then(function () {
 			console.log("Cleaned up.");
 			jqUnit.fail("The test sequence for testing success cases of API fails with this error: ", error.message);
-		} catch (e) {
+		}).catch(function (e) {
 			console.log("Failed at the clean up with an error: ", e.message);
 			jqUnit.fail("The test sequence for testing success cases of API fails with this error: ", error.message);
-		};
+		});
 	}
-	jqUnit.start();
 });
 
 //****************** Test fetchRemoteFile() - Not found case ******************

--- a/tests/gitOpsApiTests.js
+++ b/tests/gitOpsApiTests.js
@@ -41,7 +41,7 @@ const repoNameWrong = "nonexistent-repo";
 //****************** Success cases ******************
 
 jqUnit.test("Success cases for all API functions - ", function () {
-	jqUnit.expect(8);
+	jqUnit.expect(9);
 
 	return gitOpsApi.createBranch(octokit, {
 		repoOwner: repoOwner,
@@ -73,6 +73,14 @@ jqUnit.test("Success cases for all API functions - ", function () {
 		});
 	}).then(function (res) {
 		jqUnit.assertTrue("createSingleFile() completes successfully.", res.includes("has been created successfully."));
+		return gitOpsApi.getFileLastCommit(octokit, {
+			repoOwner: repoOwner,
+			repoName: repoName,
+			branchName: branchName,
+			filePath: filePath
+		});
+	}).then(function (res) {
+		jqUnit.assertTrue("getFileLastCommit() completes successfully.", typeof res.author === "object");
 		return gitOpsApi.fetchRemoteFile(octokit, {
 			repoOwner: repoOwner,
 			repoName: repoName,
@@ -137,6 +145,21 @@ jqUnit.test("Success cases for all API functions - ", function () {
 	});
 });
 
+//****************** Test fetchRemoteFile() - Not found case ******************
+jqUnit.test("Test fetchRemoteFile() - the file does not exist", function () {
+	jqUnit.expect(1);
+	return gitOpsApi.fetchRemoteFile(octokit, {
+		repoOwner: repoOwner,
+		repoName: repoNameWrong,
+		branchName: branchName,
+		filePath: "src/_data/answers.json"
+	}).then(function (response) {
+		jqUnit.assertFalse("File is not found.", response.exists);
+	}).catch(function () {
+		jqUnit.fail("fetchRemoteFile() should not fail.");
+	});
+});
+
 //****************** Failed cases ******************
 
 //****************** Test createBranch() ******************
@@ -190,6 +213,21 @@ jqUnit.test("Failed case for getAllBranches()", function () {
 		repoName: repoNameWrong
 	}).then(function () {
 		jqUnit.fail("getAllBranches() should not complete successfully.");
+	}).catch(function (error) {
+		jqUnit.assertTrue("The value of isError is set to true", error.isError);
+	});
+});
+
+//****************** Test getFileLastCommit() ******************
+jqUnit.test("Failed case for getFileLastCommit()", function () {
+	jqUnit.expect(1);
+	return gitOpsApi.getFileLastCommit(octokit, {
+		repoOwner: repoOwner,
+		repoName: repoNameWrong,
+		branchName: branchName,
+		filePath: "src/_data/answers.json"
+	}).then(function () {
+		jqUnit.fail("getFileLastCommit() should not complete successfully.");
 	}).catch(function (error) {
 		jqUnit.assertTrue("The value of isError is set to true", error.isError);
 	});


### PR DESCRIPTION
Other than adding a new API function, this pull request also does:

1. Simplify nested promise chains in API functions by using `try`, `catch`, `throw`;
2. Restructure directories: create two directories: "/lib" for the API script `gitOpsApi.js`; "demos" for ODC fetching scripts;
3. Work with the new repo name "git-ops-api".